### PR TITLE
feat: add wiki embedding pipeline (parser, embedder, pipeline runner)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,7 @@
 
 ## What This Project Does
 
-Personal AI tutor that embeds my Obsidian wiki and raw learning sources into ChromaDB, then teaches me back through conversational RAG. Two modes: "teach" (explain topics, answer questions with sources) and "test" (quiz me, evaluate my answers, show gaps). Inspired by Karibu's document → knowledge → conversational learning architecture.
-
+Personal AI tutor that embeds my Obsidian wiki and raw learning sources into ChromaDB, then teaches me back through conversational RAG. Two modes: "teach" (explain topics, answer questions with sources) and "test" (quiz me, evaluate my answers, show gaps).
 ## Tech Stack
 
 - **Language**: Python 3.12+
@@ -85,3 +84,4 @@ learnmate/
 ## Current Status
 
 - 2026-04-08: Repo created. Project structure set up. Ready for embedding pipeline.
+- 2026-04-08: Wiki embedding pipeline built (parser + embedder + pipeline runner). 33 wiki docs parsed successfully. Awaiting OpenAI API key to run first embedding.

--- a/decisions.md
+++ b/decisions.md
@@ -27,3 +27,17 @@ Claude updates this file automatically after each decision.
 **Why**: Practice real git workflow discipline. Matches the project templates we built.
 **Alternatives**: Single main branch (simpler but no release discipline).
 **Impact**: All feature branches come from develop. PRs required for every merge.
+
+### 2026-04-08 | Wiki = 1 chunk per file, no splitting
+
+**Decision**: Each wiki markdown file becomes one document in ChromaDB without further chunking.
+**Why**: Wiki files are short (800–4000 chars). Splitting would break context and create fragments too small to be useful. Retrieval quality is better with whole documents at this scale.
+**Alternatives**: Split by heading (standard for long docs), fixed-size chunks with overlap (LangChain default).
+**Impact**: Simpler pipeline — no chunking logic needed for wiki. Raw sources will use heading-based chunking later since they're longer.
+
+### 2026-04-08 | ChromaDB native embedding over LangChain wrapper
+
+**Decision**: Use ChromaDB's built-in `OpenAIEmbeddingFunction` instead of LangChain's embedding classes for the ingest pipeline.
+**Why**: Ingest is just embed + store. LangChain's VectorStore abstraction adds complexity without benefit here. LangChain will be used in the chat/retrieval module where its chain/graph features actually matter.
+**Alternatives**: LangChain Chroma integration (langchain-chroma) for both ingest and retrieval.
+**Impact**: Fewer dependencies at ingest time. Clean separation: ingest uses ChromaDB directly, chat uses LangChain.

--- a/src/ingest/embedder.py
+++ b/src/ingest/embedder.py
@@ -1,0 +1,72 @@
+"""Embed documents and store them in ChromaDB.
+
+Takes parsed wiki documents (from parser.py), generates embeddings via
+OpenAI API, and upserts them into a persistent ChromaDB collection.
+"""
+
+import chromadb
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+from src.utils.config import (
+    CHROMA_COLLECTION_NAME,
+    CHROMA_PERSIST_DIR,
+    EMBEDDING_MODEL,
+    OPENAI_API_KEY,
+)
+
+
+def get_collection() -> chromadb.Collection:
+    """Connect to (or create) the ChromaDB collection with OpenAI embeddings.
+
+    Uses persistent storage so vectors survive between runs.
+    The collection uses OpenAI's embedding function directly —
+    ChromaDB handles calling the API when documents are added.
+
+    Returns:
+        A ChromaDB Collection ready for upsert/query operations.
+    """
+    client = chromadb.PersistentClient(path=str(CHROMA_PERSIST_DIR))
+
+    embedding_fn = OpenAIEmbeddingFunction(
+        api_key=OPENAI_API_KEY,
+        model_name=EMBEDDING_MODEL,
+    )
+
+    collection = client.get_or_create_collection(
+        name=CHROMA_COLLECTION_NAME,
+        embedding_function=embedding_fn,
+    )
+
+    return collection
+
+
+def upsert_documents(documents: list[dict]) -> int:
+    """Embed and store documents in ChromaDB.
+
+    Uses upsert so re-running the pipeline updates existing documents
+    instead of creating duplicates.
+
+    Args:
+        documents: List of dicts from load_wiki_documents().
+            Each must have keys: id, content, metadata.
+
+    Returns:
+        Number of documents upserted.
+    """
+    if not documents:
+        return 0
+
+    collection = get_collection()
+
+    # ChromaDB accepts batch upsert — send all at once
+    ids = [doc["id"] for doc in documents]
+    contents = [doc["content"] for doc in documents]
+    metadatas = [doc["metadata"] for doc in documents]
+
+    collection.upsert(
+        ids=ids,
+        documents=contents,
+        metadatas=metadatas,
+    )
+
+    return len(ids)

--- a/src/ingest/parser.py
+++ b/src/ingest/parser.py
@@ -1,0 +1,85 @@
+"""Parse Obsidian wiki markdown files and extract content with metadata.
+
+Each wiki file becomes one document. Frontmatter (type, updated) is extracted
+as metadata. The rest of the file becomes the document content.
+"""
+
+from pathlib import Path
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split a markdown file into frontmatter metadata and body content.
+
+    Args:
+        text: Raw markdown file content.
+
+    Returns:
+        A tuple of (metadata dict, body string). If no frontmatter found,
+        metadata is empty and body is the full text.
+    """
+    metadata: dict[str, str] = {}
+
+    if not text.startswith("---"):
+        return metadata, text
+
+    # Find the closing --- of frontmatter
+    end_index = text.find("---", 3)
+    if end_index == -1:
+        return metadata, text
+
+    frontmatter_block = text[3:end_index].strip()
+    body = text[end_index + 3:].strip()
+
+    # Parse simple key: value pairs
+    for line in frontmatter_block.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            metadata[key.strip()] = value.strip()
+
+    return metadata, body
+
+
+def load_wiki_documents(wiki_path: Path) -> list[dict]:
+    """Load all markdown files from the wiki directory.
+
+    Walks through wiki subfolders (concepts/, entities/, sources/) and
+    creates one document per file with metadata.
+
+    Args:
+        wiki_path: Path to the Obsidian wiki directory.
+
+    Returns:
+        A list of dicts, each with keys: id, content, metadata.
+        metadata contains: filename, type, updated, subfolder.
+    """
+    documents: list[dict] = []
+
+    # Only process wiki content folders, skip index/log/bridge
+    content_folders = ["concepts", "entities", "sources"]
+
+    for folder_name in content_folders:
+        folder = wiki_path / folder_name
+        if not folder.exists():
+            continue
+
+        for md_file in sorted(folder.glob("*.md")):
+            text = md_file.read_text(encoding="utf-8")
+            metadata, body = parse_frontmatter(text)
+
+            if not body.strip():
+                continue
+
+            doc = {
+                "id": f"{folder_name}/{md_file.stem}",
+                "content": body,
+                "metadata": {
+                    "filename": md_file.stem,
+                    "subfolder": folder_name,
+                    "type": metadata.get("type", "unknown"),
+                    "updated": metadata.get("updated", ""),
+                    "source_url": metadata.get("source_url", ""),
+                },
+            }
+            documents.append(doc)
+
+    return documents

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -1,0 +1,46 @@
+"""Main ingest pipeline — parse wiki files and store embeddings.
+
+Run this module to ingest all wiki documents into ChromaDB:
+    python -m src.ingest.pipeline
+"""
+
+from src.ingest.embedder import upsert_documents
+from src.ingest.parser import load_wiki_documents
+from src.utils.config import WIKI_PATH
+
+
+def run_wiki_ingest() -> None:
+    """Parse wiki markdown files and embed them into ChromaDB.
+
+    Steps:
+        1. Load all .md files from wiki/concepts, entities, sources
+        2. Extract frontmatter metadata + body content
+        3. Upsert into ChromaDB with OpenAI embeddings
+    """
+    print(f"Wiki path: {WIKI_PATH}")
+
+    if not WIKI_PATH.exists():
+        print(f"ERROR: Wiki path does not exist: {WIKI_PATH}")
+        return
+
+    # Step 1-2: Parse
+    print("Parsing wiki documents...")
+    documents = load_wiki_documents(WIKI_PATH)
+    print(f"Found {len(documents)} documents")
+
+    if not documents:
+        print("No documents to embed. Check your wiki path.")
+        return
+
+    # Preview what we found
+    for doc in documents:
+        print(f"  - {doc['id']} ({doc['metadata']['type']})")
+
+    # Step 3: Embed and store
+    print("\nEmbedding and storing in ChromaDB...")
+    count = upsert_documents(documents)
+    print(f"Done! {count} documents upserted to ChromaDB.")
+
+
+if __name__ == "__main__":
+    run_wiki_ingest()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,21 @@
+"""Application configuration loaded from environment variables."""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+# OpenAI
+OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+EMBEDDING_MODEL: str = "text-embedding-3-small"
+
+# ChromaDB
+CHROMA_PERSIST_DIR: Path = Path(os.getenv("CHROMA_PERSIST_DIR", "./data/chromadb"))
+CHROMA_COLLECTION_NAME: str = "wiki"
+
+# Source paths
+WIKI_PATH: Path = Path(os.getenv("WIKI_PATH", ""))
+RAW_PATH: Path = Path(os.getenv("RAW_PATH", ""))


### PR DESCRIPTION
- parser.py: parse Obsidian wiki markdown files, extract frontmatter + body
- embedder.py: connect to ChromaDB, upsert documents with OpenAI embeddings
- pipeline.py: main entry point that ties parsing and embedding together
- config.py: load environment variables for API keys and paths
- Remove Karibu reference from CLAUDE.md
- Log chunking and embedding architecture decisions

Tested parser against 33 wiki documents — all parse correctly. Embedding awaits OpenAI API key configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a wiki embedding pipeline with document parsing and ChromaDB vector storage integration.
  * Successfully parsed 33 wiki documents, ready for embedding upon OpenAI API key configuration.

* **Documentation**
  * Updated project status documentation to reflect completed embedding pipeline implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->