### PR TITLE
feat: add incremental sync to embedding pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,9 @@ learnmate/
 
 ### Git & PR
 
-- Three permanent branches: `develop` (active work), `main` (stable), `prod` (live).
-- All feature/fix work branches from `develop` and merges back to `develop` via PR.
+- Three permanent branches: `develop` (active work), `main` (stable, updated only with explicit approval), `prod` (empty until first production deploy).
+- `develop` is the default working branch. All feature/fix branches come from `develop` and merge back via PR.
+- `prod` is an orphan branch — starts empty, only receives from `main` when deploying to production.
 - Never push directly to `develop`, `main`, or `prod`.
 - Every task starts with a GitHub issue. No branch without an issue.
 - Use `feature/#X-short-description` or `fix/#X-short-description` for branch names.

--- a/src/ingest/embedder.py
+++ b/src/ingest/embedder.py
@@ -2,7 +2,10 @@
 
 Takes parsed wiki documents (from parser.py), generates embeddings via
 OpenAI API, and upserts them into a persistent ChromaDB collection.
+Supports incremental sync — only new/changed docs are embedded.
 """
+
+import hashlib
 
 import chromadb
 from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
@@ -40,33 +43,90 @@ def get_collection() -> chromadb.Collection:
     return collection
 
 
-def upsert_documents(documents: list[dict]) -> int:
-    """Embed and store documents in ChromaDB.
+def _content_hash(text: str) -> str:
+    """Generate MD5 hash of document content for change detection.
 
-    Uses upsert so re-running the pipeline updates existing documents
-    instead of creating duplicates.
+    Args:
+        text: Document content string.
+
+    Returns:
+        Hex digest of the MD5 hash.
+    """
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+def sync_documents(documents: list[dict]) -> dict[str, int]:
+    """Incrementally sync documents to ChromaDB.
+
+    Compares content hashes to detect changes:
+    - New documents → embed and add
+    - Changed documents → re-embed and update
+    - Deleted documents (in DB but not in wiki) → remove
+    - Unchanged documents → skip
 
     Args:
         documents: List of dicts from load_wiki_documents().
             Each must have keys: id, content, metadata.
 
     Returns:
-        Number of documents upserted.
+        Dict with counts: {"added": N, "updated": N, "deleted": N, "skipped": N}
     """
-    if not documents:
-        return 0
-
     collection = get_collection()
+    stats = {"added": 0, "updated": 0, "deleted": 0, "skipped": 0}
 
-    # ChromaDB accepts batch upsert — send all at once
-    ids = [doc["id"] for doc in documents]
-    contents = [doc["content"] for doc in documents]
-    metadatas = [doc["metadata"] for doc in documents]
+    # Build a map of incoming docs: id → (content, metadata)
+    incoming = {}
+    for doc in documents:
+        doc_hash = _content_hash(doc["content"])
+        metadata = {**doc["metadata"], "content_hash": doc_hash}
+        incoming[doc["id"]] = {"content": doc["content"], "metadata": metadata}
 
-    collection.upsert(
-        ids=ids,
-        documents=contents,
-        metadatas=metadatas,
-    )
+    # Get all existing doc IDs and their hashes from ChromaDB
+    existing_ids: list[str] = []
+    existing_hashes: dict[str, str] = {}
+    if collection.count() > 0:
+        existing = collection.get(include=["metadatas"])
+        existing_ids = existing["ids"]
+        for doc_id, meta in zip(existing["ids"], existing["metadatas"]):
+            existing_hashes[doc_id] = meta.get("content_hash", "")
 
-    return len(ids)
+    # Find docs to add or update
+    to_upsert_ids: list[str] = []
+    to_upsert_contents: list[str] = []
+    to_upsert_metadatas: list[dict] = []
+
+    for doc_id, data in incoming.items():
+        new_hash = data["metadata"]["content_hash"]
+
+        if doc_id not in existing_hashes:
+            # New document
+            to_upsert_ids.append(doc_id)
+            to_upsert_contents.append(data["content"])
+            to_upsert_metadatas.append(data["metadata"])
+            stats["added"] += 1
+        elif existing_hashes[doc_id] != new_hash:
+            # Content changed
+            to_upsert_ids.append(doc_id)
+            to_upsert_contents.append(data["content"])
+            to_upsert_metadatas.append(data["metadata"])
+            stats["updated"] += 1
+        else:
+            stats["skipped"] += 1
+
+    # Upsert new/changed docs in one batch
+    if to_upsert_ids:
+        collection.upsert(
+            ids=to_upsert_ids,
+            documents=to_upsert_contents,
+            metadatas=to_upsert_metadatas,
+        )
+
+    # Find docs to delete (in DB but no longer in wiki)
+    incoming_ids = set(incoming.keys())
+    to_delete = [doc_id for doc_id in existing_ids if doc_id not in incoming_ids]
+
+    if to_delete:
+        collection.delete(ids=to_delete)
+        stats["deleted"] = len(to_delete)
+
+    return stats

--- a/src/ingest/parser.py
+++ b/src/ingest/parser.py
@@ -28,7 +28,7 @@ def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
         return metadata, text
 
     frontmatter_block = text[3:end_index].strip()
-    body = text[end_index + 3:].strip()
+    body = text[end_index + 3 :].strip()
 
     # Parse simple key: value pairs
     for line in frontmatter_block.splitlines():

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -4,18 +4,19 @@ Run this module to ingest all wiki documents into ChromaDB:
     python -m src.ingest.pipeline
 """
 
-from src.ingest.embedder import upsert_documents
+from src.ingest.embedder import sync_documents
 from src.ingest.parser import load_wiki_documents
 from src.utils.config import WIKI_PATH
 
 
 def run_wiki_ingest() -> None:
-    """Parse wiki markdown files and embed them into ChromaDB.
+    """Parse wiki markdown files and incrementally sync to ChromaDB.
 
     Steps:
         1. Load all .md files from wiki/concepts, entities, sources
         2. Extract frontmatter metadata + body content
-        3. Upsert into ChromaDB with OpenAI embeddings
+        3. Compare content hashes with ChromaDB
+        4. Only embed new/changed docs, remove deleted ones
     """
     print(f"Wiki path: {WIKI_PATH}")
 
@@ -26,20 +27,21 @@ def run_wiki_ingest() -> None:
     # Step 1-2: Parse
     print("Parsing wiki documents...")
     documents = load_wiki_documents(WIKI_PATH)
-    print(f"Found {len(documents)} documents")
+    print(f"Found {len(documents)} documents in wiki")
 
     if not documents:
         print("No documents to embed. Check your wiki path.")
         return
 
-    # Preview what we found
-    for doc in documents:
-        print(f"  - {doc['id']} ({doc['metadata']['type']})")
+    # Step 3-4: Incremental sync
+    print("Syncing with ChromaDB...")
+    stats = sync_documents(documents)
 
-    # Step 3: Embed and store
-    print("\nEmbedding and storing in ChromaDB...")
-    count = upsert_documents(documents)
-    print(f"Done! {count} documents upserted to ChromaDB.")
+    print("\nSync complete:")
+    print(f"  Added:   {stats['added']}")
+    print(f"  Updated: {stats['updated']}")
+    print(f"  Deleted: {stats['deleted']}")
+    print(f"  Skipped: {stats['skipped']} (unchanged)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace full re-embed with content hash comparison:
- New docs → embed and add
- Changed docs → re-embed and update
- Deleted docs → remove from ChromaDB
- Unchanged docs → skip (zero API cost)

Tested: second run skips all 33 docs, no API calls made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Git workflow: `develop` is the default working branch, `main` requires explicit approval, and `prod` is reserved for production deployments.

* **New Features**
  * Ingest pipeline now displays detailed synchronization statistics including counts of added, updated, deleted, and unchanged documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->